### PR TITLE
Formatting OperationId for Powershell cmdlets

### DIFF
--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Graph.OpenAPIService
                 return subsetOpenApiDocument;
             }
 
-            // For Powershell and PowerPlatform styles
+            /* For Powershell and PowerPlatform Styles */
 
             // Clone doc before making changes
             subsetOpenApiDocument = Clone(subsetOpenApiDocument);
@@ -197,22 +197,13 @@ namespace Microsoft.Graph.OpenAPIService
             var anyOfRemover = new AnyOfRemover();
             var walker = new OpenApiWalker(anyOfRemover);
             walker.Walk(subsetOpenApiDocument);
-
-            // Format OperationId for Powershell cmdlet names generation by separating the method group from operation name with an underscore(_) 
+                        
             if (style == OpenApiStyle.Powershell)
-            {                                                         
-                var key = subsetOpenApiDocument.Paths.Keys.First();
-                var operationId = subsetOpenApiDocument.Paths[key].Operations[OperationType.Get].OperationId;
-
-                // The last '.' character of the OperationId value separates the method group from the operation name
-                int charPos = operationId.LastIndexOf('.', operationId.Length - 1);
-                if (charPos >= 0 )
-                {
-                    StringBuilder newOperationId = new StringBuilder(operationId);
-
-                    newOperationId[charPos] = '_';
-                    subsetOpenApiDocument.Paths[key].Operations[OperationType.Get].OperationId = newOperationId.ToString();
-                }
+            {
+                // Format the OperationId for Powershell cmdlet names generation 
+                var operationIdFormatter = new OperationIdPowershellFormatter();
+                walker = new OpenApiWalker(operationIdFormatter);
+                walker.Walk(subsetOpenApiDocument);                
             }
                         
             return subsetOpenApiDocument;

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 
 namespace Microsoft.Graph.OpenAPIService
 {
@@ -183,15 +184,37 @@ namespace Microsoft.Graph.OpenAPIService
 
         public static OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument)
         {
-            if (style == OpenApiStyle.PowerPlatform || style == OpenApiStyle.Powershell)
+            if (style == OpenApiStyle.Plain)
             {
-                // Clone doc before making changes
-                subsetOpenApiDocument = Clone(subsetOpenApiDocument);
-
-                var anyOfRemover = new AnyOfRemover();
-                var walker = new OpenApiWalker(anyOfRemover);
-                walker.Walk(subsetOpenApiDocument);
+                return subsetOpenApiDocument;
             }
+
+            // For Powershell and PowerPlatform styles
+
+            // Clone doc before making changes
+            subsetOpenApiDocument = Clone(subsetOpenApiDocument);
+
+            var anyOfRemover = new AnyOfRemover();
+            var walker = new OpenApiWalker(anyOfRemover);
+            walker.Walk(subsetOpenApiDocument);
+
+            // Format OperationId for Powershell cmdlet names generation by separating the method group from operation name with an underscore(_) 
+            if (style == OpenApiStyle.Powershell)
+            {                                                         
+                var key = subsetOpenApiDocument.Paths.Keys.First();
+                var operationId = subsetOpenApiDocument.Paths[key].Operations[OperationType.Get].OperationId;
+
+                // The last '.' character of the OperationId value separates the method group from the operation name
+                int charPos = operationId.LastIndexOf('.', operationId.Length - 1);
+                if (charPos >= 0 )
+                {
+                    StringBuilder newOperationId = new StringBuilder(operationId);
+
+                    newOperationId[charPos] = '_';
+                    subsetOpenApiDocument.Paths[key].Operations[OperationType.Get].OperationId = newOperationId.ToString();
+                }
+            }
+                        
             return subsetOpenApiDocument;
         }
 
@@ -218,7 +241,7 @@ namespace Microsoft.Graph.OpenAPIService
                 throw new Exception("Failed to retrieve OpenApi document");
             }
 
-            var stream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult(); ;
+            var stream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
 
             var newrules = ValidationRuleSet.GetDefaultRuleSet().Rules
                 .Where(r => r.GetType() != typeof(ValidationRule<OpenApiSchema>)).ToList();

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -101,8 +101,8 @@ namespace Microsoft.Graph.OpenAPIService
         public static Func<OpenApiOperation, bool> CreatePredicate(string operationIds, string tags)
         {
             if (operationIds != null && tags != null)
-            {
-                return null;
+            {                
+                return null; // Cannot filter by OperationIds and Tags at the same time
             }
 
             Func<OpenApiOperation, bool> predicate;

--- a/OpenAPIService/OperationIdPowershellFormatter.cs
+++ b/OpenAPIService/OperationIdPowershellFormatter.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Graph.OpenAPIService
     /// </summary>
     internal class OperationIdPowershellFormatter : OpenApiVisitorBase
     {
-        public override void Visit(OpenApiPathItem pathItem)
+        public override void Visit(OpenApiOperation operation)
         {
-            var operationId = pathItem.Operations[OperationType.Get].OperationId; 
+            var operationId = operation.OperationId;                        
 
             int charPos = operationId.LastIndexOf('.', operationId.Length - 1);
             if (charPos >= 0)
@@ -20,7 +20,7 @@ namespace Microsoft.Graph.OpenAPIService
                 StringBuilder newOperationId = new StringBuilder(operationId);
 
                 newOperationId[charPos] = '_';
-                pathItem.Operations[OperationType.Get].OperationId = newOperationId.ToString();
+                operation.OperationId = newOperationId.ToString();
             }
         }
     }

--- a/OpenAPIService/OperationIdPowershellFormatter.cs
+++ b/OpenAPIService/OperationIdPowershellFormatter.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+using System.Text;
+
+namespace Microsoft.Graph.OpenAPIService
+{
+    /// <summary>
+    /// The last '.' character of the OperationId value separates the method group from the operation name.
+    /// This is replaced with an '_' to format the OperationId to allow for the creation of logical Powershell cmdlet names
+    /// </summary>
+    internal class OperationIdPowershellFormatter : OpenApiVisitorBase
+    {
+        public override void Visit(OpenApiPathItem pathItem)
+        {
+            var operationId = pathItem.Operations[OperationType.Get].OperationId; 
+
+            int charPos = operationId.LastIndexOf('.', operationId.Length - 1);
+            if (charPos >= 0)
+            {
+                StringBuilder newOperationId = new StringBuilder(operationId);
+
+                newOperationId[charPos] = '_';
+                pathItem.Operations[OperationType.Get].OperationId = newOperationId.ToString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR seeks to update the `OperationId` property of an OpenAPI document structure when Powershell style has been specified as an argument. 